### PR TITLE
Fixed screen clearing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import json
-import os 
+import os
 import sys
 import time
 import random
@@ -76,7 +76,7 @@ while True:
     
     if response in ['1', 'one', 's'] or response.startswith('start'):
         if os.name == 'nt':
-            _ = os.system('cls')
+            os.system('cls')
         else:
             os.system('clear')
 
@@ -110,7 +110,7 @@ while True:
             continue
 
         if os.name == 'nt':
-            _ = os.system('cls')
+            os.system('cls')
         else:
             os.system('clear')
         printdelay(
@@ -128,7 +128,7 @@ When you see the text appear, DO NOT START. You will have some time to prepare, 
                     break
 
         if os.name == 'nt':
-            _ = os.system('cls')
+            os.system('cls')
         else:
             os.system('clear')
         printdelay(f"""\033[1mYour text is:{colorend}\n
@@ -167,7 +167,7 @@ Take this time to read the text. You will see "GO!" when you are allowed to star
             abswpm = rawwpm * (accuracy / 100)
 
             if os.name == 'nt':
-                _ = os.system('cls')
+                os.system('cls')
             else:
                 os.system('clear')
 
@@ -211,7 +211,7 @@ Added to user records.
 
     if response.lower() in ['2', 'view', 'sand bar', 'two']:
         if os.name == 'nt':
-            _ = os.system('cls')
+            os.system('cls')
         else:
             os.system('clear')
         if user == []:
@@ -241,7 +241,7 @@ Added to user records.
 
     if response.lower() in ['3', 'improve', 'scour', 'three']:
         if os.name == 'nt':
-            _ = os.system('cls')
+            os.system('cls')
         else:
             os.system('clear')
         printdelay(f"""\033[1mBest typing resources{colorend}\n

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import json
-from os import system,name
+import os 
 import sys
 import time
 import random
@@ -75,8 +75,8 @@ while True:
         sys.exit(0)
     
     if response in ['1', 'one', 's'] or response.startswith('start'):
-        if name == 'nt':
-            _ = system('cls')
+        if os.name == 'nt':
+            _ = os.system('cls')
         else:
             os.system('clear')
 
@@ -109,8 +109,8 @@ while True:
                 break
             continue
 
-        if name == 'nt':
-            _ = system('cls')
+        if os.name == 'nt':
+            _ = os.system('cls')
         else:
             os.system('clear')
         printdelay(
@@ -127,8 +127,8 @@ When you see the text appear, DO NOT START. You will have some time to prepare, 
                 if isready.lower() == 'ready':
                     break
 
-        if name == 'nt':
-            _ = system('cls')
+        if os.name == 'nt':
+            _ = os.system('cls')
         else:
             os.system('clear')
         printdelay(f"""\033[1mYour text is:{colorend}\n
@@ -166,8 +166,8 @@ Take this time to read the text. You will see "GO!" when you are allowed to star
             rawwpm = cpm / 4.7
             abswpm = rawwpm * (accuracy / 100)
 
-            if name == 'nt':
-                _ = system('cls')
+            if os.name == 'nt':
+                _ = os.system('cls')
             else:
                 os.system('clear')
 
@@ -210,8 +210,8 @@ Added to user records.
             printoptions()
 
     if response.lower() in ['2', 'view', 'sand bar', 'two']:
-        if name == 'nt':
-            _ = system('cls')
+        if os.name == 'nt':
+            _ = os.system('cls')
         else:
             os.system('clear')
         if user == []:
@@ -240,8 +240,8 @@ Added to user records.
         printoptions()
 
     if response.lower() in ['3', 'improve', 'scour', 'three']:
-        if name == 'nt':
-            _ = system('cls')
+        if os.name == 'nt':
+            _ = os.system('cls')
         else:
             os.system('clear')
         printdelay(f"""\033[1mBest typing resources{colorend}\n

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import json
-import os
+from os import system,name
 import sys
 import time
 import random
@@ -75,7 +75,10 @@ while True:
         sys.exit(0)
     
     if response in ['1', 'one', 's'] or response.startswith('start'):
-        os.system('clear')
+        if name == 'nt':
+            _ = system('cls')
+        else:
+            os.system('clear')
 
         printdelay(f"""\033[1;34mCamel Racing (typing test){colorend}\n
 \033[1mDifficulty Options
@@ -106,7 +109,10 @@ while True:
                 break
             continue
 
-        os.system('clear')
+        if name == 'nt':
+            _ = system('cls')
+        else:
+            os.system('clear')
         printdelay(
             f"""\033[1mSelected difficulty: {color}{selectedtext[1]}{colorend}
 				
@@ -121,7 +127,10 @@ When you see the text appear, DO NOT START. You will have some time to prepare, 
                 if isready.lower() == 'ready':
                     break
 
-        os.system('clear')
+        if name == 'nt':
+            _ = system('cls')
+        else:
+            os.system('clear')
         printdelay(f"""\033[1mYour text is:{colorend}\n
 \033[1;34m{selectedtext[0]}{colorend}\n
 Take this time to read the text. You will see "GO!" when you are allowed to start. Press ENTER when you have finished the test.
@@ -157,7 +166,10 @@ Take this time to read the text. You will see "GO!" when you are allowed to star
             rawwpm = cpm / 4.7
             abswpm = rawwpm * (accuracy / 100)
 
-            os.system('clear')
+            if name == 'nt':
+                _ = system('cls')
+            else:
+                os.system('clear')
 
             now = datetime.now()
             user.append({
@@ -198,7 +210,10 @@ Added to user records.
             printoptions()
 
     if response.lower() in ['2', 'view', 'sand bar', 'two']:
-        os.system('clear')
+        if name == 'nt':
+            _ = system('cls')
+        else:
+            os.system('clear')
         if user == []:
             print('You don\'t have any recorded times. Do a camel race first!')
             printoptions()
@@ -225,7 +240,10 @@ Added to user records.
         printoptions()
 
     if response.lower() in ['3', 'improve', 'scour', 'three']:
-        os.system('clear')
+        if name == 'nt':
+            _ = system('cls')
+        else:
+            os.system('clear')
         printdelay(f"""\033[1mBest typing resources{colorend}\n
 Other Typing Tests:
   - monkeytype (monkeytype.com)


### PR DESCRIPTION
the method `os.system('clear')` does not exist on windows devices. 
The windows of equivalent of it would be `os.system('cls')`
I checked the user's os with `os.name` (returns 'nt' if user is on windows), and depending on their os, it either uses `os.system('cls')` or `os.system('clear')`
This allows people to use it on all OS without any bugs. 
